### PR TITLE
adding functionality to support deprecation of components

### DIFF
--- a/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/ComponentNodeContainer.js
+++ b/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/ComponentNodeContainer.js
@@ -242,9 +242,23 @@ export default class ComponentNodeContainer extends Component {
           imgPath = "styles/img/"+iconsFrom+"icon-custom.png";
           subType = 'Custom';
         }
-        return (<NodeContainer accepts={nodeType} dataArr={toolbarTypeArr} moveIcon={this.moveIcon.bind(this)} onDrop={this.onDrop.bind(this)} index={i} key={i} imgPath={imgPath} name={nodeName} type={source.type} nodeLable={nodeName} nodeType={subType} hideSourceOnDrag={false} topologyComponentBundleId={source.id} defaultImagePath={defaultImagePath} testRunActivated={testRunActivated} eventLogData/>);
+        let isDeprecated = source.deprecated;
+        return (<NodeContainer
+          accepts={nodeType} dataArr={toolbarTypeArr} moveIcon={this.moveIcon.bind(this)}
+          onDrop={this.onDrop.bind(this)} index={i} key={i} imgPath={imgPath} name={nodeName}
+          type={source.type} nodeLable={nodeName} nodeType={subType} hideSourceOnDrag={false}
+          topologyComponentBundleId={source.id} defaultImagePath={defaultImagePath}
+          testRunActivated={testRunActivated} eventLogData deprecated={isDeprecated}
+        />);
       }else if(s && s.type == 'folder'){
-        return (<NodeContainer accepts={editToolbar ? nodeType : ''} onFolderNameChange={this.onFolderNameChange.bind(this)} editToolbar={editToolbar} data={s} dataArr={toolbarTypeArr} dropArr={s.children} moveIcon={this.moveIcon.bind(this)} onDrop={this.onDrop.bind(this)} index={i} viewType="folder" key={i} imgPath={"styles/img/"+iconsFrom+"/icon-.png"} name={s.name} type={''} nodeLable={''} nodeType={''} hideSourceOnDrag={false} topologyComponentBundleId={999} defaultImagePath='' testRunActivated={testRunActivated}>{
+        return (<NodeContainer
+          accepts={editToolbar ? nodeType : ''} onFolderNameChange={this.onFolderNameChange.bind(this)}
+          editToolbar={editToolbar} data={s} dataArr={toolbarTypeArr} dropArr={s.children}
+          moveIcon={this.moveIcon.bind(this)} onDrop={this.onDrop.bind(this)} index={i} viewType="folder"
+          key={i} imgPath={"styles/img/"+iconsFrom+"/icon-.png"} name={s.name} type={''} nodeLable={''}
+          nodeType={''} hideSourceOnDrag={false} topologyComponentBundleId={999} defaultImagePath={defaultImagePath}
+          testRunActivated={testRunActivated}
+        >{
             s.children.map((child, i) => {
               const source = _.find(entityTypeArr, {id: child.bundleId});
               nodeName = source.name.toUpperCase();
@@ -257,7 +271,15 @@ export default class ComponentNodeContainer extends Component {
                 imgPath = "styles/img/"+iconsFrom+"icon-custom.png";
                 subType = 'Custom';
               }
-              return (<NodeContainer accepts={nodeType} dataArr={s.children} isChildren={true} moveIcon={this.moveIcon.bind(this)} index={i} key={i} imgPath={imgPath} name={nodeName} type={source.type} nodeLable={nodeName} nodeType={subType} hideSourceOnDrag={false} topologyComponentBundleId={source.id} defaultImagePath={defaultImagePath} testRunActivated={testRunActivated} eventLogData={eventLogData}/>);
+              let isDeprecated = source.deprecated;
+              return (<NodeContainer
+                accepts={nodeType} dataArr={s.children} isChildren={true}
+                moveIcon={this.moveIcon.bind(this)} index={i} key={i} imgPath={imgPath}
+                name={nodeName} type={source.type} nodeLable={nodeName} nodeType={subType}
+                hideSourceOnDrag={false} topologyComponentBundleId={source.id}
+                defaultImagePath={defaultImagePath} testRunActivated={testRunActivated}
+                eventLogData={eventLogData} deprecated={isDeprecated}
+              />);
             })
           }</NodeContainer>);
       }else{

--- a/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/NodeContainer.jsx
+++ b/webservice/src/main/resources/app/scripts/containers/Streams/TopologyEditor/NodeContainer.jsx
@@ -97,7 +97,7 @@ const nodeTarget = {
 
 const nodeSource = {
   canDrag(props , monitor){
-    return !props.testRunActivated;
+    return !props.deprecated && !props.testRunActivated;
   },
   beginDrag(props, monitor, component) {
     return _.clone(props);
@@ -126,7 +126,8 @@ export default class NodeContainer extends Component {
     nodeType: PropTypes.string.isRequired,
     topologyComponentBundleId: PropTypes.number.isRequired,
     defaultImagePath: PropTypes.string.isRequired,
-    testRunActivated : PropTypes.bool.isRequired
+    testRunActivated : PropTypes.bool.isRequired,
+    deprecated: PropTypes.bool
   };
 
   getPopover() {
@@ -152,12 +153,16 @@ export default class NodeContainer extends Component {
       connectDropTarget,
       viewType,
       children,
-      accepts
+      accepts,
+      deprecated
     } = this.props;
     const showHighlight = canDrop && isOver;
     let className = [];
     if(showHighlight && !this.props.isChildren){
       className.push('highlight');
+    }
+    if (deprecated){
+      className.push('deprecated');
     }
     if((!viewType && accepts != ItemTypes.Nodes) || (viewType == 'folder' && accepts != '')){
       className.push.apply(className, ['tada', 'animated', 'infinite']);
@@ -166,14 +171,16 @@ export default class NodeContainer extends Component {
       <li className={className.join(' ')}>
         { viewType != 'folder'
         ?
-        <div className="nodeContainer"><span className="drag-handle"></span><img src={imgPath} ref="img" style={{filter: 'url(#blue-wash)'}} onError={() => {
-          this.refs.img.src = defaultImagePath;
-        }}/></div>
+          <div className="nodeContainer"><span className={deprecated ? "" : "drag-handle"}></span><img src={imgPath} ref="img" style={{filter: 'url(#blue-wash)'}} onError={() => {
+            this.refs.img.src = defaultImagePath;
+          }}/></div>
         :
         <OverlayTrigger trigger="click" rootClose placement="right" ref="folderOverlay" overlay={this.getPopover()}>
           <div className={"nodeContainerFolder"}>
             {children.map((child, i) => {
-              return <img src={child.props.imgPath} key={i}/>;
+              return <img src={child.props.imgPath} ref="folderImg" key={i} onError={() => {
+                this.refs.folderImg.src = defaultImagePath;
+              }}/>;
             })}
           </div>
         </OverlayTrigger>

--- a/webservice/src/main/resources/app/styles/css/style.css
+++ b/webservice/src/main/resources/app/styles/css/style.css
@@ -1346,6 +1346,10 @@ label {
   width: 24px;
 }
 
+.component-list>li.deprecated>div.nodeContainer>img {
+  pointer-events: none;
+}
+
 .drag-handle {
   content: '';
   position: absolute;
@@ -6435,4 +6439,9 @@ background: #fff
 
 .pagination > .active > a, .pagination > .active > span, .pagination > .active > a:hover, .pagination > .active > span:hover, .pagination > .active > a:focus, .pagination > .active > span:focus{
   z-index: 0;
+}
+.deprecated {
+  cursor: not-allowed;
+  filter: grayscale(1);
+  opacity: 0.75;
 }


### PR DESCRIPTION
<img width="296" alt="Screenshot 2019-06-26 at 12 43 22 PM" src="https://user-images.githubusercontent.com/6761317/60159079-04446280-9810-11e9-9704-e04b0004ac9d.png">

As shown in the above image, deprecated components will be visible in the toolbar but it won't be draggable to add new in the DAG.

To mark a component deprecated, just add `deprecated: true` in any components json file at the top level